### PR TITLE
[fix] <?php detection in settings.php

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,6 +10,9 @@ location __PATH__/ {
   }
 
   index index.php;
+  if (!-e $request_filename) {
+    rewrite ^__PATH__/(.+)$ __PATH__/index.php?q=$1 last;
+  }
 
   try_files $uri $uri/ index.php;
   location ~ [^/]\.php(/|$) {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,8 +10,9 @@ location __PATH__/ {
   }
 
   index index.php;
+
   if (!-e $request_filename) {
-    rewrite ^__PATH__/(.+)$ __PATH__/index.php?q=$1 last;
+    rewrite ^__PATH__/(.*)$ __PATH__/index.php?q=$1 last;
   }
 
   try_files $uri $uri/ index.php;

--- a/conf/settings.php
+++ b/conf/settings.php
@@ -13,7 +13,8 @@
      * https://api.backdropcms.org/database-configuration
      */
     $database = 'mysql://__DBNAME__:__DBPWD__@localhost/__DBNAME__';
-    $database_prefix = '';
+    $database_prefix = '__DBNAME___';
+    $database_charset = 'utf8mb4';
 
     /**
      * Site configuration files location.

--- a/conf/settings.php
+++ b/conf/settings.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
     /**
      * @file
      * Main Backdrop CMS configuration file.

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,6 +6,9 @@
 
 YNH_PHP_VERSION="7.3"
 
+extra_php_dependencies="php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-xmlrpc php${YNH_PHP_VERSION}-soap php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-zip"
+
+
 #=================================================
 # PERSONAL HELPERS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -91,7 +91,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Configuring PHP-FPM..." --weight=2
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION
+ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
 phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -117,8 +117,8 @@ ynh_store_file_checksum --file="$final_path/settings.php"
 #=================================================
 
 # Set permissions to app files
-chown -R root: $final_path
-chown -R $app:www-data $final_path/files
+chown -R $app:www-data $final_path
+#chown -R $app:www-data $final_path/files
 chmod -R 770 $final_path/files
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -49,8 +49,9 @@ ynh_remove_nginx_config
 #=================================================
 ynh_script_progression --message="Removing PHP-FPM configuration..." --weight=3
 
-# Remove the dedicated PHP-FPM config
-ynh_remove_fpm_config
+ynh_restore_file --origin_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
+
+ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -103,7 +103,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Upgrading PHP-FPM configuration..." --weight=2
 
 # Create a dedicated PHP-FPM config
-ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION
+ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem
- The install process thought the `settings.php` file pushed by YNH was not formatted properly, adding an extra `<?php`

## Solution
- Remove the extra spaces at the beginning of the first line.